### PR TITLE
fix: update friendship change validator range to -3..3

### DIFF
--- a/lib/validator/schema_validator.rb
+++ b/lib/validator/schema_validator.rb
@@ -15,7 +15,7 @@ module Validator
   ##
   class SchemaValidator < BaseValidator
     VALID_ACTIONS = ['sell', 'refuse', 'negotiate', 'talk'].freeze
-    FRIENDSHIP_RANGE = (-10..10).freeze
+    FRIENDSHIP_RANGE = (-3..3).freeze
 
     # Validates the JSON structure and business rules.
     #
@@ -66,7 +66,7 @@ module Validator
       return unless friendship
       return if FRIENDSHIP_RANGE.cover?(friendship)
 
-      raise ValidationError, "Friendship value must be between -10 and 10"
+      raise ValidationError, "Friendship value must be between -3 and 3"
     end
   end
 end

--- a/spec/lib/validator/schema_validator_spec.rb
+++ b/spec/lib/validator/schema_validator_spec.rb
@@ -72,29 +72,29 @@ RSpec.describe Validator::SchemaValidator do
     end
 
     context 'when friendship is below minimum' do
-      let(:row) { CSV::Row.new(['output'], ['{"action":"refuse","message":"No","parameters":{"friendship_change":-11}}']) }
+      let(:row) { CSV::Row.new(['output'], ['{"action":"refuse","message":"No","parameters":{"friendship_change":-4}}']) }
 
       it 'is expected to raise ValidationError' do
-        expect { validation_result }.to raise_error(ValidationError, 'Friendship value must be between -10 and 10')
+        expect { validation_result }.to raise_error(ValidationError, 'Friendship value must be between -3 and 3')
       end
     end
 
     context 'when friendship is above maximum' do
-      let(:row) { CSV::Row.new(['output'], ['{"action":"sell","message":"Thanks","parameters":{"price":50,"friendship_change":11}}']) }
+      let(:row) { CSV::Row.new(['output'], ['{"action":"sell","message":"Thanks","parameters":{"price":50,"friendship_change":4}}']) }
 
       it 'is expected to raise ValidationError' do
-        expect { validation_result }.to raise_error(ValidationError, 'Friendship value must be between -10 and 10')
+        expect { validation_result }.to raise_error(ValidationError, 'Friendship value must be between -3 and 3')
       end
     end
 
     context 'when friendship is at minimum boundary' do
-      let(:row) { CSV::Row.new(['output'], ['{"action":"refuse","message":"No","parameters":{"friendship_change":-10}}']) }
+      let(:row) { CSV::Row.new(['output'], ['{"action":"refuse","message":"No","parameters":{"friendship_change":-3}}']) }
 
       it { is_expected.to be true }
     end
 
     context 'when friendship is at maximum boundary' do
-      let(:row) { CSV::Row.new(['output'], ['{"action":"sell","message":"Here","parameters":{"price":50,"friendship_change":10}}']) }
+      let(:row) { CSV::Row.new(['output'], ['{"action":"sell","message":"Here","parameters":{"price":50,"friendship_change":3}}']) }
 
       it { is_expected.to be true }
     end


### PR DESCRIPTION
Fixes #16

Updated friendship change validation to match the specification in `docs/features/validation.md`. Changed valid range from -10 to 10 to -3 to +3.

### Changes
- Updated `FRIENDSHIP_RANGE` constant from `(-10..10)` to `(-3..3)`
- Updated error message to reflect new range
- Updated test cases for boundary values and error conditions

### Testing
- 73 examples, 0 failures
- 98.67% code coverage

----

Generated with [Claude Code](https://claude.ai/code)